### PR TITLE
Fix Leaflet 1.9.4 SRI hashes

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -3,7 +3,12 @@
 {% block title %}Map View - Inventory Tracker{% endblock %}
 
 {% block extra_head %}
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+vx6kGPR/HIcPp3dGVi8nrpGL2N1Yw9A4JHFKZ3h0=" crossorigin=""/>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
   <style>
     #inventory-map { height: 70vh; }
   </style>
@@ -18,7 +23,11 @@
 {% endblock %}
 
 {% block extra_scripts %}
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-DvN1M36zrHfX5Yucs5cjoxOYD65Zj50sC1LFp6Z3A6A=" crossorigin=""></script>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+  ></script>
   <script>
     const map = L.map('inventory-map').setView([0, 0], 2);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
## Summary
- update the Leaflet CSS and JS CDN tags to use the correct 1.9.4 integrity hashes so the assets load successfully

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d8374dbb6c832ea20487f9d0b69252